### PR TITLE
Fix dedicated server crash on crafting cactus armor

### DIFF
--- a/src/main/java/com/pam/desertcraft/item/ItemPamCactusArmor.java
+++ b/src/main/java/com/pam/desertcraft/item/ItemPamCactusArmor.java
@@ -1,6 +1,6 @@
 package com.pam.desertcraft.item;
 
-import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ArmorItem;
@@ -14,7 +14,7 @@ public class ItemPamCactusArmor extends ArmorItem {
 	}
 
 	public void onCreated(ItemStack ItemStack, World World, PlayerEntity PlayerEntity) {
-		ItemStack.addEnchantment(Enchantment.getEnchantmentByID(7), 1);
+		ItemStack.addEnchantment(Enchantments.THORNS, 1);
 	}
 
 }


### PR DESCRIPTION
The function `Enchantment.getEnchantmentByID` is a client only method, leading to the dedicated server crashing when attempted to be called when the user crafts cactus armor. I have corrected the code to use the thorns enchantment constant.

Crash report snippet:
```
java.lang.NoSuchMethodError: net.minecraft.enchantment.Enchantment.func_185262_c(I)Lnet/minecraft/enchantment/Enchantment;
	at com.pam.desertcraft.item.ItemPamCactusArmor.func_77622_d(ItemPamCactusArmor.java:17) ~[?:1.0.17-b1] {re:classloading}
```

Also wanting to note, when developing this PR I noticed the repo does not reflect the latest release on curseforge, as there is extraneous code and assets from bonecraft still present. Additionally, the build script is missing the variable interpolation which comes standard with the mdk used for the "mods.toml", leading to the mod's version being the placeholder "${version}" in the released jar.